### PR TITLE
Added family name, credit name, and other names to record summary

### DIFF
--- a/src/pyorcid/orcid.py
+++ b/src/pyorcid/orcid.py
@@ -161,7 +161,7 @@ class Orcid():
      
     def other_names(self):
         '''
-        Other names by which the researcher is know
+        Other names by which the researcher is known
         return  :
         '''
         return self.__read_section("other-names") 
@@ -396,7 +396,7 @@ class Orcid():
 
         return True
 
-    def __get_value_from_keys(self,json_obj, keys):
+    def __get_value_from_keys(self, json_obj, keys):
         """
         Get the value associated with the last key in the list if all keys are accessible cumulatively.
 
@@ -459,6 +459,9 @@ class Orcid():
         data = self.record()
         extracted_data = {
             'Name': self.__get_value_from_keys(data,["person","name","given-names","value"]),
+            'Family Name': self.__get_value_from_keys(data,["person","name","family-name","value"]),
+            'Credit Name': self.__get_value_from_keys(data,["person","name","credit-name","value"]),
+            'Other Names': [name['content'] for name in self.__get_value_from_keys(data,["person","other-names","other-name"])],
             'Biography': self.__get_value_from_keys(data,["person","biography","content"]),
             'Emails': [email['email'] for email in self.__get_value_from_keys(data,["person","emails","email"])],
             'Research Tags (keywords)': [keyword['content'] for keyword in self.__get_value_from_keys(data,["person","keywords","keyword"])],


### PR DESCRIPTION
Great package! Thanks for building this, @sri0606.

I had need for all names to be available in the record summary. This change keeps given-name as the Name property in the summary as that is the only required name that will always be present in an ORCID record, adds properties for "Family Name" and "Credit Name" where those are available (credit name often as the full name and most reasonable label for a person), and adds "Other Names" as a list of the content values from those. I tested this on a range of ORCID identifiers without issue.

I'm going to keep working with my fork in practice and may address the following:
- Add a parameter for formatting choice on biography to simply include the string value in the record_summary
- Add parameters to select elements to include in the record_summary