### PR TITLE
added optional parameter to use sandbox urls

### DIFF
--- a/src/pyorcid/orcid.py
+++ b/src/pyorcid/orcid.py
@@ -7,7 +7,7 @@ class Orcid():
     '''
     This is a wrapper class for ORCID API
     '''
-    def __init__(self,orcid_id, orcid_access_token = " ", state="public") -> None:
+    def __init__(self,orcid_id, orcid_access_token = " ", state="public", sandbox=False) -> None:
         '''
         Initialize orcid instance
         orcid_id : Orcid ID of the user
@@ -17,6 +17,7 @@ class Orcid():
         self._orcid_id = orcid_id
         self._orcid_access_token = orcid_access_token
         self._state = state
+        self._sandbox = sandbox
         #For testing purposes (pytesting on github workflow)
         if orcid_access_token!=" ":
             try:
@@ -45,12 +46,14 @@ class Orcid():
 
         if self._state == "public":
             # Specify the ORCID record endpoint for the desired ORCID iD
-            # api_url = f'https://pub.sandbox.orcid.org/v3.0/{self._orcid_id}'  #for testing
             api_url = f'https://pub.orcid.org/v3.0/{self._orcid_id}'
+            if(self._sandbox):
+                api_url = f'https://pub.sandbox.orcid.org/v3.0/{self._orcid_id}'  #for testing
 
         elif self._state == "member":
-            # api_url = f'https://api.sandbox.orcid.org/v3.0/{self._orcid_id}'  #for testing
             api_url = f'https://api.orcid.org/v3.0/{self._orcid_id}'
+            if(self._sandbox):
+                api_url = f'https://api.sandbox.orcid.org/v3.0/{self._orcid_id}'  #for testing
 
         response = requests.get(api_url, headers=headers)
 
@@ -79,12 +82,15 @@ class Orcid():
 
         if self._state == "public":
             # Specify the ORCID record endpoint for the desired ORCID iD
-            # api_url = f'https://pub.sandbox.orcid.org/v3.0/{self._orcid_id}'  #for testing
             api_url = f'https://pub.orcid.org/v3.0/{self._orcid_id}/{section}'
+            if(self._sandbox):
+                api_url = f'https://pub.sandbox.orcid.org/v3.0/{self._orcid_id}/{section}'  #for testing
 
         elif self._state == "member":
-            # api_url = f'https://api.sandbox.orcid.org/v3.0/{self._orcid_id}'  #for testing
             api_url = f'https://api.orcid.org/v3.0/{self._orcid_id}/{section}'
+            if(self._sandbox):
+                api_url = f'https://api.sandbox.orcid.org/v3.0/{self._orcid_id}/{section}'  #for testing
+
 
         # Make a GET request to retrieve the ORCID record
         response = requests.get(api_url, headers=headers)

--- a/src/pyorcid/orcid_authentication.py
+++ b/src/pyorcid/orcid_authentication.py
@@ -7,7 +7,7 @@ class OrcidAuthentication:
     The Orcid's OAuth 2.0 authorrization is used to access the ORCID record of the user that gave access.
     
     '''
-    def __init__(self, client_id, client_secret, redirect_uri=""):
+    def __init__(self, client_id, client_secret, redirect_uri="", sandbox=False):
         '''
         initializes the ORCidAuthentication and gets the access token
         Parameters
@@ -15,11 +15,13 @@ class OrcidAuthentication:
         client_id : str : client id obtained from the registered application
         client_secret : str : client secret obtained from the registered application
         redirect_uri : str : redirect uri obtained from the registered application
+        sandbox : str : a boolean value to show if the ORCID sandbox API should be used (default: False)
 
         '''
         self.__client_id = client_id
         self.__client_secret = client_secret
         self.__redirect_uri = redirect_uri
+        self.__sandbox = sandbox
         return None
     
     
@@ -30,12 +32,13 @@ class OrcidAuthentication:
         Requires user authorization
         '''
 
-       # Set the necessary parameters
-        # auth_url_endpoint = "https://sandbox.orcid.org/oauth/authorize"   #for testing
-        # token_url = "https://sandbox.orcid.org/oauth/token"               #for testing
-
+        # Set the necessary parameters
         auth_url_endpoint = "https://orcid.org/oauth/authorize"
         token_url = "https://orcid.org/oauth/token"
+
+        if(self.__sandbox):
+            auth_url_endpoint = "https://sandbox.orcid.org/oauth/authorize"
+            token_url = "https://sandbox.orcid.org/oauth/token"
 
         # Step 1: Redirect the user to the authorization URL
         params = {
@@ -73,6 +76,10 @@ class OrcidAuthentication:
         """
         scope='/read-public'
         token_url = "https://orcid.org/oauth/token"
+        
+        if(self.__sandbox):
+            token_url = "https://sandbox.orcid.org/oauth/token"
+
         params = {
             'client_id': self.__client_id,
             'client_secret': self.__client_secret,


### PR DESCRIPTION
When starting out, testing or developing with this library it is useful not directly send all of the request to the regular API but instead to the dedicated ORCID sandbox. This change adds an optional parameter that would actively cause the endpoint URL be switched from the regular API to the sandbox. Since the default is set to False, this change is backward compatible with existing implementations that use this library.